### PR TITLE
update docs

### DIFF
--- a/gold-zip-input.html
+++ b/gold-zip-input.html
@@ -16,10 +16,31 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 <link rel="import" href="zip-validator.html">
 
 <!--
-`gold-zip-input` is a Material Design field for entering a valid US zip code.
-Example:
+`gold-zip-input` is a single-line text field with Material Design styling
+for entering a US zip code.
 
     <gold-zip-input></gold-zip-input>
+
+It may include an optional label, which by default is "Zip Code".
+
+    <gold-zip-input label="Mailing zip code"></gold-zip-input>
+
+### Validation
+
+The input supports both 5 digit zip codes (90210) or the full 9 digit ones,
+separated by a dash (90210-9999).
+
+The input can be automatically validated as the user is typing by using
+the `auto-validate` and `required` attributes. For manual validation, the
+element also has a `validate()` method, which returns the validity of the
+input as well sets any appropriate error messages and styles.
+
+See `Polymer.PaperInputBehavior` for more API docs.
+
+### Styling
+
+See `Polymer.PaperInputContainer` for a list of custom properties used to
+style this element.
 
 @group Gold Elements
 @hero hero.svg


### PR DESCRIPTION
Docs! Blatantly lifted from `paper-input` and carried across all the gold elements.

/cc @cdata