### PR TITLE
add autocomplete field

### DIFF
--- a/gold-zip-input.html
+++ b/gold-zip-input.html
@@ -73,7 +73,7 @@ style this element.
           type="tel"
           maxlength="10"
           bind-value="{{value}}"
-          autocomplete$="[[autocomplete]]"
+          autocomplete="postal-code"
           name$="[[name]]">
 
       <template is="dom-if" if="[[errorMessage]]">


### PR DESCRIPTION
Apparently the `autocomplete` field has meaning. See: https://developers.google.com/web/fundamentals/input/form/label-and-name-inputs?hl=en

It worked by magic in some of the elements because they had a heuristic-approved name in the demo, but now it works regardless of the name.

/cc @morethanreal @cdata 
