### PR TITLE
automatically format full zip codes

### DIFF
--- a/gold-zip-input.html
+++ b/gold-zip-input.html
@@ -75,6 +75,8 @@ style this element.
           required$="[[required]]"
           validator="zip-validator"
           type="tel"
+          allowed-pattern="[0-9\-]"
+          prevent-invalid-input
           maxlength="10"
           bind-value="{{value}}"
           autocomplete="postal-code"
@@ -114,6 +116,31 @@ style this element.
       label: {
         type: String,
         value: "Zip Code"
+      }
+    },
+
+    observers: [
+      '_computeValue(value)'
+    ],
+
+    _computeValue: function(value) {
+      var start = this.$.input.selectionStart;
+      var previousCharADash = this.value.charAt(start - 1) == '-';
+
+      // Remove any already-applied formatting.
+      value = value.replace(/-/g, '');
+
+      // Add a dash after the 5th character
+      if (value.length > 5) {
+        value = value.substr(0,5) + '-' + value.substr(5)
+      }
+      this.updateValueAndPreserveCaret(value.trim());
+
+      // If the character right before the selection is a newly inserted
+      // dash, we need to advance the selection to maintain the caret position.
+      if (!previousCharADash && this.value.charAt(start - 1) == '-') {
+        this.$.input.selectionStart = start + 1;
+        this.$.input.selectionEnd = start + 1;
       }
     }
 

--- a/test/basic.html
+++ b/test/basic.html
@@ -49,14 +49,10 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
         assert.isTrue(container.invalid);
       });
 
-      test('too many dashes are not ok', function() {
+      test('input is formatted ok', function() {
         var input = fixture('basic');
-        input.value='90210--1111';
-        forceXIfStamp(input);
-
-        var container = Polymer.dom(input.root).querySelector('paper-input-container');
-        assert.ok(container, 'paper-input-container exists');
-        assert.isTrue(container.invalid);
+        input.value='902101111';
+        assert.equal(input.value, '90210-1111');
       });
 
       test('spaces instead of dashes are not ok', function() {
@@ -96,6 +92,18 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
         var error = Polymer.dom(input.root).querySelector('paper-input-error');
         assert.ok(error, 'paper-input-error exists');
         assert.notEqual(getComputedStyle(error).display, 'none', 'error is not display:none');
+      });
+
+      test('caret position is preserved', function() {
+        var input = fixture('basic');
+        var ironInput = Polymer.dom(input.root).querySelector('input[is="iron-input"]');
+        input.value='11111-11';
+        ironInput.selectionStart = 2;
+        ironInput.selectionEnd = 2;
+        input._computeValue('11221-1111');
+
+        assert.equal(ironInput.selectionStart, 2, 'selectionStart is preserved');
+        assert.equal(ironInput.selectionEnd, 2, 'selectionEnd is preserved');
       });
 
     });


### PR DESCRIPTION
Automatically add the dash after the 5th character  (so `902101` is formatted as `90210-1`)

This is basically the same thing that `gold-phone-input` and `gold-cc-input` are doing, but different :)

/cc @morethanreal 