### PR TITLE
Invalid Null Input

### DIFF
--- a/gold-zip-input.html
+++ b/gold-zip-input.html
@@ -121,7 +121,7 @@ style this element.
         ],
 
         _computeValue: function(value) {
-          value = String(value);
+          value = String(value != null && value || '');
           var start = this.$.input.selectionStart;
           var previousCharADash = value.charAt(start - 1) === '-';
 

--- a/test/basic.html
+++ b/test/basic.html
@@ -102,6 +102,13 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
         assert.equal(ironInput.selectionEnd, 2, 'selectionEnd is preserved');
       });
 
+      test('null input behaves like empty string', function() {
+        var input = fixture('basic');
+        input.value = null;
+
+        assert.equal(input.value, '');
+      });
+
     });
 
     suite('a11y', function() {


### PR DESCRIPTION
Treat input values of `null` as an empty string. 

Fixes #34  