### PR TITLE
fix: prevent undefined values from displaying as "undef-ined"

### DIFF
--- a/gold-zip-input.html
+++ b/gold-zip-input.html
@@ -121,7 +121,7 @@ style this element.
         ],
 
         _computeValue: function(value) {
-          value = String(value);
+          value = String((value === undefined || value === null) ? '' : value);
           var start = this.$.input.selectionStart;
           var previousCharADash = value.charAt(start - 1) === '-';
 


### PR DESCRIPTION
This fixes #36 by assigning an empty string to undefined values.