### PR TITLE
Fix TypeScript compilation of gold-zip-input

### DIFF
--- a/gold-zip-input.d.ts
+++ b/gold-zip-input.d.ts
@@ -49,6 +49,7 @@ interface GoldZipInputElement extends Polymer.Element, Polymer.PaperInputBehavio
    * The label for this input.
    */
   label: string|null|undefined;
+  value: string|null|undefined;
 
   /**
    * Returns a reference to the focusable element. Overridden from PaperInputBehavior

--- a/gold-zip-input.html
+++ b/gold-zip-input.html
@@ -177,6 +177,11 @@ style this element.
           label: {
             type: String,
             value: "Zip Code"
+          },
+
+          value: {
+            // Required for the correct TypeScript type-generation
+            type: String
           }
 
         },


### PR DESCRIPTION
As a result of a TypeScript update in `IronFormElementBehavior` (https://github.com/PolymerElements/iron-form-element-behavior/pull/41) to address an issue in `paper-slider` (https://github.com/Polymer/gen-typescript-declarations/issues/103) this inadvertently broke the compilation of `gold-zip-input`. The fix is the same as for `paper-slider`, declare `value` again with the correct type in the concrete subclass.